### PR TITLE
Enable client Gzip compression, as stated in coincap API docs

### DIFF
--- a/pkg/coincap/client.go
+++ b/pkg/coincap/client.go
@@ -55,7 +55,7 @@ func (c *Client) fetchAndParse(req *http.Request) (*coincapResp, error) {
 	}
 	defer resp.Body.Close()
 
-	// check if the serfer sent compressed data
+	// check if the server sent compressed data
 	var reader io.ReadCloser
 	switch resp.Header.Get("Content-Encoding") {
 	case "gzip":

--- a/pkg/coincap/client.go
+++ b/pkg/coincap/client.go
@@ -66,7 +66,7 @@ func (c *Client) fetchAndParse(req *http.Request) (*coincapResp, error) {
 		}
 		defer reader.Close()
 	default:
-		// otherwise set the reader to the response bodt
+		// otherwise set the reader to the response body
 		reader = resp.Body
 	}
 

--- a/pkg/coincap/client.go
+++ b/pkg/coincap/client.go
@@ -2,8 +2,10 @@
 package coincap
 
 import (
+	"compress/gzip"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net/http"
 )
@@ -43,6 +45,8 @@ type coincapResp struct {
 // fetchAndParse returns the json below the top level "data" key
 // returned by the coincap api
 func (c *Client) fetchAndParse(req *http.Request) (*coincapResp, error) {
+	// add the gzip compression header
+	req.Header.Add("Accept-Encoding", "gzip")
 
 	// make request to the api and read the response
 	resp, err := c.httpClient.Do(req)
@@ -51,7 +55,23 @@ func (c *Client) fetchAndParse(req *http.Request) (*coincapResp, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	// check if the serfer sent compressed data
+	var reader io.ReadCloser
+	switch resp.Header.Get("Content-Encoding") {
+	case "gzip":
+		// if the content encoding was gzip instantiate a new gzip reader
+		reader, err = gzip.NewReader(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+		defer reader.Close()
+	default:
+		// otherwise set the reader to the response bodt
+		reader = resp.Body
+	}
+
+	// now read the body out of the reader
+	body, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/coincap/go.mod
+++ b/pkg/coincap/go.mod
@@ -1,0 +1,5 @@
+module github.com/haukened/coincapV2/pkg/coincap
+
+go 1.13
+
+require github.com/gorilla/mux v1.7.3

--- a/pkg/coincap/go.sum
+++ b/pkg/coincap/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
+github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=

--- a/pkg/coincap/rates_test.go
+++ b/pkg/coincap/rates_test.go
@@ -121,7 +121,7 @@ func TestRatesMalformed(t *testing.T) {
 
 	rates, _, err := client.Rates()
 	if err == nil {
-		t.Errorf("Expected malformed json %s", rates)
+		t.Errorf("Expected malformed json %+v", rates)
 	}
 }
 


### PR DESCRIPTION
This PR enables client gzip compression support, as indicated in the coincap API docs.

In addition to that change, and to conform with modern go standards, `go mod init` created `go.mod` and `go.sum` to modularize the package.

I also fixed an issue noticed by `go vet` where an `Errorf` statement was printing a `Rate` struct via `%s` which was changed to `%+v` in order to properly print the struct in a debug setting.